### PR TITLE
set the redirect URL dynamically based on hostname

### DIFF
--- a/controllers/Google.php
+++ b/controllers/Google.php
@@ -31,7 +31,7 @@
             $client = new Google_Client();
             $client->setClientId(Settings::get('google_client_id'));
             $client->setClientSecret(Settings::get('google_client_secret'));
-            $client->setRedirectUri(Settings::get('google_redirect_uri'));
+            $client->setRedirectUri('http://' . Request::getHttpHost() . '/backend/martin/ssologin/google');
             $client->setScopes('email');
 
             # HANDLE LOGOUTS


### PR DESCRIPTION
That way, authentication will also work for instances where you run
October on multiple subdomains. Comes in very handy when you also
use the keios/multisite plugin, which allows you to map themes
to hostnames dynamically

We currently use keios/multisite, since we're hosting multiple themes in one October instance, and we can then just point users to themeA.oursite.com or themeB.oursite.com, and they'll only see the content they need to worry about.

We also use this plugin, which always redirects the user to a fixed host that is stored in the database. 

With that change, the redirect IP is depending on the origin of the request.