### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,10 @@
 {
-    "name": "martin/login",
+    "name": "martin/ssologin-plugin",
+    "type": "october-plugin",
+    "description": "SSO Login for October CMS",
+    "homepage": "https://octobercms.com/plugin/martin-ssologin",
+    "keywords": ["october", "cms", "google", "sso", "login"],
     "require": {
-        "google/apiclient": "^2.0.0@RC"
+        "google/apiclient": "^2.0.3"
     }
 }


### PR DESCRIPTION
When installing a plugin into octobercms, the generated directory inside plugins will be `{composer-vendor}/{composer-projectname}`. If composer project name has the suffix `-plugin`, it is removed.
I modified the composer.json file so the name of the project is the same as the namespace used in the plugin, also added the october-plugin type so it is installed in the plugins directory and no under vendor.
It would be nice also to have it published in packagist, so we do not need to add a repository section in our composer.json file.
Gracias por el plugin, vamo' arriba.